### PR TITLE
Upgrading for the ElasticSuite 2.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "magento/framework": ">=100.2.0",
     "magento/module-quick-order": ">=100.0.0",
     "magento/magento-composer-installer": "*",
-    "smile/elasticsuite": "~2.10.0"
+    "smile/elasticsuite": "~2.11.0"
   },
   "require-dev": {
      "smile/magento2-smilelab-quality-suite": "^1.1.0"


### PR DESCRIPTION
# What was the issue
B2B store upgrading to 2.4.6 was not able to get the shared catalog and the quickorder to install due to compose dependencies

# What was done
- Small changes to get better compatibility with PHP 8.x 
- Updated composer to be compatible with ElasticSuite 2.11